### PR TITLE
Add prefix to error message

### DIFF
--- a/Python/scoreSubmission.py
+++ b/Python/scoreSubmission.py
@@ -110,5 +110,6 @@ if __name__ == '__main__':
     try:
         scoreAll(args)
     except Exception as e:
-        print(str(e), file=sys.stderr)
+        covalicErrorPrefix = 'covalic.error: '
+        print(covalicErrorPrefix + str(e), file=sys.stderr)
         exit(1)


### PR DESCRIPTION
This allows the Covalic Girder plugin to distinguish errors from the scoring
container from its job log.

See https://github.com/girder/covalic/pull/170
