### PR TITLE
Ignore __MACOSX metadata directory in zip files

### DIFF
--- a/Python/scoreSubmission.py
+++ b/Python/scoreSubmission.py
@@ -29,6 +29,9 @@ def extractZip(path, dest, flatten=True):
     with zipfile.ZipFile(path) as zf:
         if flatten:
             for name in zf.namelist():
+                # Ignore Mac OS X metadata
+                if name.startswith('__MACOSX'):
+                    continue
                 outName = os.path.basename(name)
                 # Skip directories
                 if not outName:


### PR DESCRIPTION
Zip files created on Mac OS X might include a folder with metadata for files in
the archive:

```
./submission/ISIC_0000003_Segmentation.png
./__MACOSX/submission/._ISIC_0000003_Segmentation.png
```

With the current error checking, the similar filename in the metadata folder
causes the error:

```
Multiple matching submissions for: ISIC_0000003_Segmentation.png
```

To avoid the error, ignore the __MACOSX metadata directory when extracting zip
files.

Fixes #15 
