### PR TITLE
Fix string formatting error

### DIFF
--- a/Python/scoreCommon.py
+++ b/Python/scoreCommon.py
@@ -34,7 +34,7 @@ def loadSegmentationImage(imagePath):
         image = Image.open(imagePath)
     except Exception as e:
         raise ScoreException('Could not decode image "%s" because: "%s"' %
-                             os.path.basename(imagePath), str(e))
+                             (os.path.basename(imagePath), str(e)))
 
     if image.mode == '1':
         # NumPy crashes if a 1-bit (black and white) image is directly


### PR DESCRIPTION
This fixes the following error when formatting the string passed to
ScoreException:

```
TypeError: not enough arguments for format string
```
