### PR TITLE
Fix usage of undefined variable name

### DIFF
--- a/Python/scoreCommon.py
+++ b/Python/scoreCommon.py
@@ -55,7 +55,7 @@ def resizeImage(image, width, height):
     return image.resize((width, height), Image.NEAREST)
 
 
-def convertToNumPyArray(image):
+def convertToNumPyArray(image, imagePath):
     """Convert PIL Image to NumPy array."""
     image = np.array(image)
 

--- a/Python/scoreP1.py
+++ b/Python/scoreP1.py
@@ -12,8 +12,8 @@ def scoreP1Image(truthPath, testPath):
     truthImage = loadSegmentationImage(truthPath)
     testImage = loadSegmentationImage(testPath)
 
-    truthImage = convertToNumPyArray(truthImage)
-    testImage = convertToNumPyArray(testImage)
+    truthImage = convertToNumPyArray(truthImage, truthPath)
+    testImage = convertToNumPyArray(testImage, testPath)
 
     if testImage.shape[0:2] != truthImage.shape[0:2]:
         raise ScoreException('Image %s has dimensions %s; expected %s.' %

--- a/Python/scoreP2B.py
+++ b/Python/scoreP2B.py
@@ -78,8 +78,8 @@ def scoreP2B(truthDir, testDir):
             testImage = resizeImage(testImage, width, height)
 
             # Convert images
-            truthImage = convertToNumPyArray(truthImage)
-            testImage = convertToNumPyArray(testImage)
+            truthImage = convertToNumPyArray(truthImage, truthPath)
+            testImage = convertToNumPyArray(testImage, testPath)
 
             # Add images to concatenated arrays
             truthArray[index * width * height : (index+1) * width * height] = truthImage.flatten()


### PR DESCRIPTION
This fixes a regression introduced in 1432d1b.

The convertToNumPyArray() function uses the 'imagePath' variable when raising a
ScoreException, but after splitting the original function that variable no
longer exists.
