### PR TITLE
Replace jaccard_similarity_score with jaccard_score

### DIFF
--- a/tests/test_metrics_comparative.py
+++ b/tests/test_metrics_comparative.py
@@ -29,10 +29,7 @@ def test_binary_jaccard_reference(truth_binary_values, prediction_binary_values)
     cm = create_binary_confusion_matrix(truth_binary_values, prediction_binary_values)
 
     value = metrics.binary_jaccard(cm)
-    # sklearn has a very idiosyncratic implementation of jaccard_similarity_score; unless the input
-    # arrays are wrapped in an additional dimension, the result is actually the accuracy score
-    # see: https://github.com/scikit-learn/scikit-learn/issues/3037
-    reference_value = sklearn.metrics.jaccard_similarity_score(
+    reference_value = sklearn.metrics.jaccard_score(
         np.expand_dims(truth_binary_values, axis=0),
         np.expand_dims(prediction_binary_values, axis=0),
     )

--- a/tests/test_metrics_comparative.py
+++ b/tests/test_metrics_comparative.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 import pytest
 import sklearn.metrics
 
@@ -29,11 +28,7 @@ def test_binary_jaccard_reference(truth_binary_values, prediction_binary_values)
     cm = create_binary_confusion_matrix(truth_binary_values, prediction_binary_values)
 
     value = metrics.binary_jaccard(cm)
-    reference_value = sklearn.metrics.jaccard_score(
-        np.expand_dims(truth_binary_values, axis=0),
-        np.expand_dims(prediction_binary_values, axis=0),
-        average='micro',
-    )
+    reference_value = sklearn.metrics.jaccard_score(truth_binary_values, prediction_binary_values)
 
     assert value == pytest.approx(reference_value)
 

--- a/tests/test_metrics_comparative.py
+++ b/tests/test_metrics_comparative.py
@@ -32,6 +32,7 @@ def test_binary_jaccard_reference(truth_binary_values, prediction_binary_values)
     reference_value = sklearn.metrics.jaccard_score(
         np.expand_dims(truth_binary_values, axis=0),
         np.expand_dims(prediction_binary_values, axis=0),
+        average='micro',
     )
 
     assert value == pytest.approx(reference_value)


### PR DESCRIPTION
jaccard_similarity_score was deprecated since version 0.21 by sklearn