### PR TITLE
Prevent ScoreException when task_num is 1 or 2

### DIFF
--- a/isic_challenge_scoring/__init__.py
+++ b/isic_challenge_scoring/__init__.py
@@ -133,7 +133,7 @@ def score_all(
         score = task1.score
     elif task_num == 2:
         score = task2.score
-    if task_num == 3:
+    elif task_num == 3:
         score = task3.score
     else:
         raise ScoreException(f'Internal error: unknown ground truth phase number: {task_num}.')


### PR DESCRIPTION
Currently, it throws a ScoreException for tasks 1 or 2. I think this is unintended, and probably a typo. The 'if task_num == 3' should be 'elif'.