### PR TITLE
Add an 'overall' field into scores

### DIFF
--- a/isic_challenge_scoring/task1.py
+++ b/isic_challenge_scoring/task1.py
@@ -21,7 +21,7 @@ def score(truth_path: pathlib.Path, prediction_path: pathlib.Path) -> Dict[str, 
         ]
     )
 
-    return {
+    scores = {
         'macro_average': {
             'threshold_jaccard': confusion_matrics.apply(
                 metrics.binary_threshold_jaccard, threshold=0.65, axis='columns'
@@ -37,3 +37,6 @@ def score(truth_path: pathlib.Path, prediction_path: pathlib.Path) -> Dict[str, 
             ).mean(),
         }
     }
+    scores['overall'] = scores['macro_average']['threshold_jaccard']
+
+    return scores

--- a/isic_challenge_scoring/task2.py
+++ b/isic_challenge_scoring/task2.py
@@ -48,4 +48,6 @@ def score(truth_path: pathlib.Path, prediction_path: pathlib.Path) -> Dict[str, 
         'dice': metrics.binary_dice(sum_confusion_matrix),
     }
 
+    score['overall'] = scores['micro_average']['jaccard']
+
     return scores

--- a/isic_challenge_scoring/task3.py
+++ b/isic_challenge_scoring/task3.py
@@ -74,6 +74,8 @@ def compute_metrics(truth_file_stream, prediction_file_stream) -> Dict[str, Dict
         )
     }
 
+    scores['overall'] = scores['aggregate']['balanced_accuracy']
+
     return scores
 
 


### PR DESCRIPTION
The name of the overall score varied from task to task. Adding the overall will
make it easier to extract the overall score.